### PR TITLE
[fix] remap P hotkey to pointer

### DIFF
--- a/UserDocs.html
+++ b/UserDocs.html
@@ -177,7 +177,7 @@
       <h1>Emphasis and Polarity</h1>
       <p>Emphasis gives selected nodes or links a thick red outline. It changes only the presentation of the diagram and has no effect on equations or results. Use it to identify a feedback loop during a presentation, show which assumptions are being reviewed, compare the active path through a process, or direct attention to the elements responsible for a particular result.</p>
       <p>Select one or more model parts and press B, which is the default Toggle Emphasis key. Press B again to remove it. Theme, Appearance, Clear All Emphasis removes every highlight. The key can be reassigned under Settings, Key Binds.</p>
-      <p>Selected influences can receive positive or negative polarity labels. P applies or removes positive polarity, and M applies or removes negative polarity by default. Polarity describes the direction of the relationship, not whether the relationship is desirable. More pollution increasing illness is positive polarity because both move in the same direction, even though the outcome is harmful.</p>
+      <p>Selected influences can receive positive or negative polarity labels. With one or more influences selected, + applies or removes positive polarity and − applies or removes negative polarity by default. When no influence is selected, + and − keep their usual role of zooming the diagram in and out. Polarity describes the direction of the relationship, not whether the relationship is desirable. More pollution increasing illness is positive polarity because both move in the same direction, even though the outcome is harmful.</p>
     </div></div></div></section>
 
     <section class="tutorialContainer"><div id="equations" class="tutorialBox"><div class="tutorialContents">
@@ -298,7 +298,7 @@
         <tr><td>Flow</td><td>F</td><td>Influence</td><td>I</td></tr>
         <tr><td>Text</td><td>T</td><td>Conveyor</td><td>N</td></tr>
         <tr><td>Microwave</td><td>W</td><td>Queue</td><td>Q</td></tr>
-        <tr><td>Positive polarity</td><td>P</td><td>Negative polarity</td><td>M</td></tr>
+        <tr><td>Positive polarity</td><td>+ (influence selected)</td><td>Negative polarity</td><td>− (influence selected)</td></tr>
         <tr><td>Toggle emphasis</td><td>B</td><td>Delete selection</td><td>Delete or Backspace</td></tr>
       </tbody></table>
     </div></div></div></section>

--- a/sim/editor.js
+++ b/sim/editor.js
@@ -478,15 +478,32 @@ function init() {
 
     buildTemplates();
 
-    // ── Diagram keyboard shortcuts: B = emphasis, P = polarity +, M = polarity - ──
+    // ── Diagram keyboard shortcuts: B = emphasis, + / - = polarity on selected influences ──
+    // GoJS normalises the +/= and - keys (main row and numpad) to "Add" / "Subtract"
+    // and, by default, uses them for increaseZoom / decreaseZoom.  We only intercept
+    // them when at least one influence link is selected; otherwise they fall through
+    // to the default CommandHandler behaviour (zoom).
+    function keyMatchesBind(gojsKey, bindKey) {
+        var k = String(gojsKey || "").toLowerCase();
+        var b = String(bindKey || "").toLowerCase();
+        if (b === "+" || b === "=" || b === "add") return k === "add" || k === "+" || k === "=";
+        if (b === "-" || b === "_" || b === "subtract") return k === "subtract" || k === "-" || k === "_";
+        return k === b;
+    }
+    function selectedInfluences() {
+        var out = [];
+        myDiagram.selection.each(function(part) {
+            if (part instanceof go.Link && part.data.category === "influence") out.push(part);
+        });
+        return out;
+    }
     myDiagram.commandHandler.doKeyDown = (function(original) {
         return function() {
             const e = myDiagram.lastInput;
             const tag = document.activeElement ? document.activeElement.tagName.toLowerCase() : "";
             if (tag !== "input" && tag !== "textarea" && !e.control && !e.meta && !e.alt) {
                 var kb = window._keyBinds || {};
-                var kdown = e.key.toLowerCase();
-                if (kdown === (kb.emphasis || 'b')) {
+                if (keyMatchesBind(e.key, kb.emphasis || 'b')) {
                     myDiagram.model.startTransaction("toggle emphasis");
                     myDiagram.selection.each(function(part) {
                         if (part instanceof go.Node || part instanceof go.Link) {
@@ -496,27 +513,21 @@ function init() {
                     myDiagram.model.commitTransaction("toggle emphasis");
                     return;
                 }
-                if (kdown === (kb['polarity-pos'] || 'p')) {
-                    myDiagram.model.startTransaction("set polarity +");
-                    myDiagram.selection.each(function(part) {
-                        if (part instanceof go.Link && part.data.category === "influence") {
+                var isPos = keyMatchesBind(e.key, kb['polarity-pos'] || '+');
+                var isNeg = !isPos && keyMatchesBind(e.key, kb['polarity-neg'] || '-');
+                if (isPos || isNeg) {
+                    var infl = selectedInfluences();
+                    if (infl.length > 0) {
+                        var pol = isPos ? "+" : "-";
+                        myDiagram.model.startTransaction("set polarity " + pol);
+                        infl.forEach(function(part) {
                             const cur = getPolarityLabelData(part);
-                            setPolarityLabel(part, cur && cur.polarity === "+" ? null : "+");
-                        }
-                    });
-                    myDiagram.model.commitTransaction("set polarity +");
-                    return;
-                }
-                if (kdown === (kb['polarity-neg'] || 'm')) {
-                    myDiagram.model.startTransaction("set polarity -");
-                    myDiagram.selection.each(function(part) {
-                        if (part instanceof go.Link && part.data.category === "influence") {
-                            const cur = getPolarityLabelData(part);
-                            setPolarityLabel(part, cur && cur.polarity === "-" ? null : "-");
-                        }
-                    });
-                    myDiagram.model.commitTransaction("set polarity -");
-                    return;
+                            setPolarityLabel(part, cur && cur.polarity === pol ? null : pol);
+                        });
+                        myDiagram.model.commitTransaction("set polarity " + pol);
+                        return;
+                    }
+                    // No influence selected → fall through (default: zoom in / out)
                 }
             }
             original.call(this);
@@ -4316,8 +4327,8 @@ document.addEventListener('DOMContentLoaded', function() {
         conveyor:     'n',
         microwave:    'w',
         queue:        'q',
-        'polarity-pos': 'p',
-        'polarity-neg': 'm',
+        'polarity-pos': '+',
+        'polarity-neg': '-',
         emphasis:     'b'
     };
 

--- a/sim/systemDynamics.html
+++ b/sim/systemDynamics.html
@@ -446,8 +446,8 @@
             <div class="keybind-row"><span>Conveyor</span>       <input class="keybind-input" id="kb-conveyor"   data-action="conveyor"   value="n" readonly></div>
             <div class="keybind-row"><span>Microwave</span>      <input class="keybind-input" id="kb-microwave"  data-action="microwave"  value="w" readonly></div>
             <div class="keybind-row"><span>Queue</span>          <input class="keybind-input" id="kb-queue"      data-action="queue"      value="q" readonly></div>
-            <div class="keybind-row"><span>Polarity +</span>     <input class="keybind-input" id="kb-polarity-pos" data-action="polarity-pos" value="p" readonly></div>
-            <div class="keybind-row"><span>Polarity −</span>     <input class="keybind-input" id="kb-polarity-neg" data-action="polarity-neg" value="m" readonly></div>
+            <div class="keybind-row"><span>Polarity +</span>     <input class="keybind-input" id="kb-polarity-pos" data-action="polarity-pos" value="+" readonly></div>
+            <div class="keybind-row"><span>Polarity −</span>     <input class="keybind-input" id="kb-polarity-neg" data-action="polarity-neg" value="-" readonly></div>
             <div class="keybind-row"><span>Toggle Emphasis</span><input class="keybind-input" id="kb-emphasis"   data-action="emphasis"   value="b" readonly></div>
           </div>
         </div>


### PR DESCRIPTION
#16 accidentally added a regression to one of the keyboard shortcuts. 
This PR remaps the keyboard shortcut P back to pointer selection.
The +/- signs from the previous PR are hotkeyed to +/- keys (when influences are selected).

Tested on localhost.